### PR TITLE
docs: surface note-taking in app descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="https://www.gnu.org/licenses/gpl-3.0"><img src="https://img.shields.io/badge/License-GPLv3-blue.svg" alt="License: GPL v3" /></a>
 </p>
 
-A lightweight, offline markdown and code file reader for Android with syntax highlighting and a built-in editor.
+A lightweight, offline markdown and code file reader for Android with syntax highlighting and a built-in editor for markdown notes.
 
 ## Features
 
@@ -18,10 +18,10 @@ A lightweight, offline markdown and code file reader for Android with syntax hig
 - 🌓 **Material You** - Dynamic color, dark and light themes, edge-to-edge display
 
 ### Editing
-- ✏️ **Built-in Editor** - Edit markdown files with a live preview tab; edit code files with syntax-aware display
+- ✏️ **Built-in Editor** - Write notes and edit markdown files with a live preview tab; edit code files with syntax-aware display
 - 🔧 **Formatting Toolbar** - Quick access to bold, italic, headings, code blocks, links, and lists while editing
 - 💾 **Save & Export** - Save edited files in place or export to a new location with Save As
-- 🆕 **Create New Files** - Start a new markdown or code file from scratch
+- 🆕 **Create New Files** - Start a new note, markdown, or code file from scratch
 
 ### App
 - 📂 **Open from Anywhere** - Open files directly from any file manager via the standard share/open intent

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,16 +1,16 @@
-MarkReader is a lightweight, offline markdown and code file reader for Android.
+MarkReader is a lightweight, offline markdown and code file reader for Android, with a built-in editor for writing markdown notes.
 
-Open markdown files to see a clean, rendered view with support for headings, bold, italic, blockquotes, inline code, fenced code blocks, and tables. Open code files to get syntax highlighting for dozens of programming languages powered by Prism4j.
+Open markdown files to see a clean, rendered view with support for headings, bold, italic, blockquotes, inline code, fenced code blocks, and tables. Open code files to get syntax highlighting for dozens of programming languages powered by Prism4j. Notes and edits are saved as ordinary .md files on your own device — no account, no sync, no lock-in.
 
 FEATURES
 
 - Markdown rendering with full CommonMark support including tables
 - Syntax highlighting for code files (Kotlin, Python, JavaScript, Java, C, C++, HTML, CSS, JSON, YAML, and more)
-- Built-in editor with markdown preview — switch between Edit and Preview tabs
+- Built-in editor for note-taking and quick edits, with markdown preview — switch between Edit and Preview tabs
 - Formatting toolbar for common markdown syntax (bold, italic, headings, code blocks, links, lists)
 - Open files directly from any file manager via the standard share/open intent
 - Save edited files back in place or export to a new location via Save As
-- Create new files from scratch
+- Create new notes and files from scratch
 - Material You design with dynamic color, dark and light themes
 - Edge-to-edge display
 - No internet required — all processing is done locally on your device

--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,1 +1,1 @@
-Offline markdown and code reader with syntax highlighting
+Offline markdown, notes, and code reader with syntax highlighting


### PR DESCRIPTION
Searching "note" or "note-taking" surfaced nothing for MarkReader. Work the wording into the store description and README without promoting it to a headline feature.

Closes #10